### PR TITLE
Allow installation on Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 	"require": {
 		"nette/utils": "^3",
 		"guzzlehttp/guzzle": "^7|^6",
-		"symfony/console": "^5",
-		"symfony/cache": "^5",
+		"symfony/console": "^5|^6",
+		"symfony/cache": "^5|^6",
 		"psr/cache": "^1",
 		"php": ">=7.3",
 		"ext-json": "*"


### PR DESCRIPTION
It is currently not possible to install on Symfony 6 any package that has a dependency on this one, because of it requiring Symofny 5 dependencies.